### PR TITLE
Fix deadlock

### DIFF
--- a/src/Vendr.PaymentProviders.Opayo/Api/OpayoClient.cs
+++ b/src/Vendr.PaymentProviders.Opayo/Api/OpayoClient.cs
@@ -29,7 +29,7 @@ namespace Vendr.PaymentProviders.Opayo.Api
         {
             var rawResponse = await MakePostRequestAsync(
                 GetMethodUrl(inputFields[OpayoConstants.TransactionRequestFields.TransactionType], useTestMode),
-                inputFields);
+                inputFields).ConfigureAwait(false);
 
             return GetFields(rawResponse);
 
@@ -116,7 +116,8 @@ namespace Vendr.PaymentProviders.Opayo.Api
 
                 return await request
                     .PostAsync(null)
-                    .ReceiveString();
+                    .ReceiveString()
+                    .ConfigureAwait(false);
             }
             catch (FlurlHttpException ex)
             {

--- a/src/Vendr.PaymentProviders.Opayo/OpayoServerPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Opayo/OpayoServerPaymentProvider.cs
@@ -60,7 +60,10 @@ namespace Vendr.PaymentProviders.Opayo
             });
 
             var inputFields = OpayoInputLoader.LoadInputs(ctx.Order, ctx.Settings, Vendr, ctx.Urls.CallbackUrl);
-            var responseDetails = await client.InitiateTransactionAsync(ctx.Settings.TestMode, inputFields);
+            var responseDetails = 
+                Task.Run( () => 
+                    client.InitiateTransactionAsync(ctx.Settings.TestMode, inputFields)
+                ).GetAwaiter().GetResult();
 
             var status = responseDetails[OpayoConstants.Response.Status];
 

--- a/src/Vendr.PaymentProviders.Opayo/OpayoServerPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Opayo/OpayoServerPaymentProvider.cs
@@ -60,10 +60,8 @@ namespace Vendr.PaymentProviders.Opayo
             });
 
             var inputFields = OpayoInputLoader.LoadInputs(ctx.Order, ctx.Settings, Vendr, ctx.Urls.CallbackUrl);
-            var responseDetails = 
-                Task.Run( () => 
-                    client.InitiateTransactionAsync(ctx.Settings.TestMode, inputFields)
-                ).GetAwaiter().GetResult();
+            var responseDetails = await client.InitiateTransactionAsync(ctx.Settings.TestMode, inputFields)
+                .ConfigureAwait(false);
 
             var status = responseDetails[OpayoConstants.Response.Status];
 


### PR DESCRIPTION
Switch out await for a task runner to manage threads.

This is in relation to [issue 5](https://github.com/vendrhub/vendr-payment-provider-opayo/issues/5)