### PR TITLE
Update opayo endpoints because the old sagepay.com urls will retire soon

### DIFF
--- a/src/Vendr.PaymentProviders.Opayo/Api/OpayoClient.cs
+++ b/src/Vendr.PaymentProviders.Opayo/Api/OpayoClient.cs
@@ -61,41 +61,12 @@ namespace Vendr.PaymentProviders.Opayo.Api
 
         private string GetMethodUrl(string type, bool testMode)
         {
-            switch (testMode)
+            if (testMode)
             {
-                case false:
-                    switch (type.ToUpperInvariant())
-                    {
-                        case "AUTHORISE":
-                            return "https://live.sagepay.com/gateway/service/authorise.vsp";
-                        case "PAYMENT":
-                        case "DEFERRED":
-                        case "AUTHENTICATE":
-                            return "https://live.sagepay.com/gateway/service/vspserver-register.vsp";
-                        case "CANCEL":
-                            return "https://live.sagepay.com/gateway/service/cancel.vsp";
-                        case "REFUND":
-                            return "https://live.sagepay.com/gateway/service/refund.vsp";
-                    }
-                    break;
-                case true:
-                    switch (type.ToUpperInvariant())
-                    {
-                        case "AUTHORISE":
-                            return "https://test.sagepay.com/gateway/service/authorise.vsp";
-                        case "PAYMENT":
-                        case "DEFERRED":
-                        case "AUTHENTICATE":
-                            return "https://test.sagepay.com/gateway/service/vspserver-register.vsp";
-                        case "CANCEL":
-                            return "https://test.sagepay.com/gateway/service/cancel.vsp";
-                        case "REFUND":
-                            return "https://test.sagepay.com/gateway/service/refund.vsp";
-                    }
-                    break;
+                return OpayoEndpoints.TestEndpoints[type.ToUpperInvariant()];
             }
 
-            return string.Empty;
+            return OpayoEndpoints.LiveEndpoints[type.ToUpperInvariant()];
         }
 
         private async Task<string> MakePostRequestAsync(string url, IDictionary<string, string> inputFields)

--- a/src/Vendr.PaymentProviders.Opayo/Api/OpayoEndpoints.cs
+++ b/src/Vendr.PaymentProviders.Opayo/Api/OpayoEndpoints.cs
@@ -2,9 +2,9 @@
 
 namespace Vendr.PaymentProviders.Opayo.Api
 {
-    internal class OpayoEndpoints
+    internal static class OpayoEndpoints
     {
-        public static IDictionary<string, string> TestEndpoints => new Dictionary<string, string>
+        private static Dictionary<string, string> TestEndpoints => new Dictionary<string, string>
         {
             { "AUTHORISE", "https://sandbox.opayo.eu.elavon.com/gateway/service/authorise.vsp" },
             { "PAYMENT", "https://sandbox.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
@@ -14,7 +14,7 @@ namespace Vendr.PaymentProviders.Opayo.Api
             { "REFUND", "https://sandbox.opayo.eu.elavon.com/gateway/service/refund.vsp" },
         };
 
-        public static IDictionary<string, string> LiveEndpoints => new Dictionary<string, string>
+        private static Dictionary<string, string> LiveEndpoints => new Dictionary<string, string>
         {
             { "AUTHORISE", "https://live.opayo.eu.elavon.com/gateway/service/authorise.vsp" },
             { "PAYMENT", "https://live.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
@@ -23,5 +23,34 @@ namespace Vendr.PaymentProviders.Opayo.Api
             { "CANCEL", "https://live.opayo.eu.elavon.com/gateway/service/cancel.vsp" },
             { "REFUND", "https://live.opayo.eu.elavon.com/gateway/service/refund.vsp" },
         };
+
+        /// <summary>
+        /// Get Opayo endpoint by type.
+        /// </summary>
+        /// <param name="endpointType"></param>
+        /// <param name="isTestMode"></param>
+        /// <returns></returns>
+        /// <exception cref="UnknownEndpointTypeException">Throws exception when unable to get the endpoint.</exception>
+        public static string Get(string endpointType, bool isTestMode)
+        {
+            string normalizeEndpointType = endpointType.ToUpperInvariant();
+
+            if (isTestMode)
+            {
+                if (!TestEndpoints.TryGetValue(normalizeEndpointType, out string testEndpoint))
+                {
+                    throw new UnknownEndpointTypeException(endpointType);
+                }
+
+                return testEndpoint;
+            }
+
+            if (!LiveEndpoints.TryGetValue(normalizeEndpointType, out string liveEndpoint))
+            {
+                throw new UnknownEndpointTypeException(endpointType);
+            }
+
+            return liveEndpoint;
+        }
     }
 }

--- a/src/Vendr.PaymentProviders.Opayo/Api/OpayoEndpoints.cs
+++ b/src/Vendr.PaymentProviders.Opayo/Api/OpayoEndpoints.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace Vendr.PaymentProviders.Opayo.Api
+{
+    internal class OpayoEndpoints
+    {
+        public static IDictionary<string, string> TestEndpoints => new Dictionary<string, string>
+        {
+            { "AUTHORISE", "https://sandbox.opayo.eu.elavon.com/gateway/service/authorise.vsp" },
+            { "PAYMENT", "https://sandbox.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "DEFERRED", "https://sandbox.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "AUTHENTICATE", "https://sandbox.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "CANCEL", "https://sandbox.opayo.eu.elavon.com/gateway/service/cancel.vsp" },
+            { "REFUND", "https://sandbox.opayo.eu.elavon.com/gateway/service/refund.vsp" },
+        };
+
+        public static IDictionary<string, string> LiveEndpoints => new Dictionary<string, string>
+        {
+            { "AUTHORISE", "https://live.opayo.eu.elavon.com/gateway/service/authorise.vsp" },
+            { "PAYMENT", "https://live.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "DEFERRED", "https://live.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "AUTHENTICATE", "https://live.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "CANCEL", "https://live.opayo.eu.elavon.com/gateway/service/cancel.vsp" },
+            { "REFUND", "https://live.opayo.eu.elavon.com/gateway/service/refund.vsp" },
+        };
+    }
+}

--- a/src/Vendr.PaymentProviders.Opayo/Api/UnknownEndpointTypeException.cs
+++ b/src/Vendr.PaymentProviders.Opayo/Api/UnknownEndpointTypeException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Globalization;
+
+namespace Vendr.PaymentProviders.Opayo.Api
+{
+    [Serializable]
+    public class UnknownEndpointTypeException : Exception
+    {
+        private const string MessageTemplate = "Unknown endpoint type '{0}'";
+
+        public UnknownEndpointTypeException()
+            : base("Unknown endpoint type")
+        {
+        }
+
+        public UnknownEndpointTypeException(string endpointType)
+            : base(string.Format(CultureInfo.InvariantCulture, MessageTemplate, endpointType))
+        {
+        }
+
+        public UnknownEndpointTypeException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
TL;DR: `sagepay.com` urls will retire on **31st March 2024** so we need to update the endpoints before that time.

Please see below email from SagePay/Opayo:

```
Hi,
  
Following the updates earlier this year with the Opayo gateway becoming a payment product under the Elavon brand; we wanted to let you know about further exciting changes.  
 
Opayo has been a key member of the Elavon family for over three years now, and as we continue with the integration into Elavon we will soon make updates to the URLs you use for your transactions and reporting.
 
What does this mean?
The URLs you use to send transactions to Opayo will be changing to an Elavon domain and you need to make the changes to send your transactions to the updated URLs. 
  
These changes must be made by 31st March 2024, this is when the SagePay URLs will cease to work.
 
We’ve already added these updated URL’s to our Developer Hub to help you make the changes, you can find the URLs specific to your integration below:
 
Pi integration
Direct integration
Form integration
Server integration
RAAPI
Shared API
 
If you’re using a shopping cart provider speak with them directly regarding this to make the relevant updates.
 
Important information
The HTTP standard of all headers is lower case with the new URLs, be aware of this if you have specific code to look for case sensitivity. 
We recommend using domain names instead of hard code, if you have hard-coded an IP address in your website or shopping cart you’ll need to update this also. 
Flush DNS cache (local) or Internet Service Provider (ISP) may cache DNS records. In this case, you will need to speak directly with your ISP to ensure you have the most up-to-date DNS records.
You will need to ensure the new URLs are whitelisted and any firewall rules you have in place have been updated. 
If you have implemented a content security policy you will also need to update this.
As always, we recommend testing any changes you make in your testing environment before implementing them to production.
 
Upgrade your protocol version 
When making these updates take this opportunity to upgrade to our latest protocol version.
 
Following previous communication on 31st January 2024 we are retiring protocol version 2.22 and 2.23, this would be a great opportunity to upgrade to our latest protocol version ensuring your transaction are processed compliantly and you have access to all the latest features that Opayo have introduced.
 
We’re here to help
For advice on making the relevant changes please contact your account manager, or contact support directly at opayosupport@elavon.com or 0191 313 0299.

Opayo by Elavon Team
```